### PR TITLE
Update label-commenter-config.yml

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -25,11 +25,11 @@ labels:
     labeled:
       issue:
         body: "🚨 Alert! Git Police! We couldn’t help but notice that one or more of your commits is missing a sign-off. _A what?_ A commit sign-off (your email address).\n\n
-         To amend the commits in this PR with your signoff using the instructions provided in the DCO check below. \n\n
+         To amend the commits in this PR with your signoff using the instructions provided in the DCO check. \n\n
          To configure your dev environment to automatically signoff on your commits in the future, see [these instructions](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)."
         action: open
       pr:
         body: "🚨 Alert! Git Police! We couldn’t help but notice that one or more of your commits is missing a sign-off. _A what?_ A commit sign-off (your email address).\n\n
-         To amend the commits in this PR with your signoff using the instructions provided in the DCO check below. \n\n
+         To amend the commits in this PR with your signoff using the instructions provided in the DCO check. \n\n
          To configure your dev environment to automatically signoff on your commits in the future, see [these instructions](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)."
         action: open


### PR DESCRIPTION
Removed the preposition "below" from lines 28 and 33

**Description**

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
